### PR TITLE
Add utility and component tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "eslint": "^8",
         "eslint-config-next": "14.1.0",
         "jest": "^29.7.0",
+        "react-test-renderer": "19.1.0",
         "typescript": "^5"
       },
       "engines": {
@@ -8894,6 +8895,27 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/react-test-renderer": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.1.0.tgz",
+      "integrity": "sha512-jXkSl3CpvPYEF+p/eGDLB4sPoDX8pKkYvRl9+rR8HxLY0X04vW7hCm1/0zHoUSjPZ3bDa+wXWNTDVIw/R8aDVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-is": "^19.1.0",
+        "scheduler": "^0.26.0"
+      },
+      "peerDependencies": {
+        "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-test-renderer/node_modules/react-is": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
+      "integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react-transition-group": {
       "version": "4.4.5",

--- a/package.json
+++ b/package.json
@@ -57,8 +57,9 @@
     "@types/react-dom": "^18",
     "eslint": "^8",
     "eslint-config-next": "14.1.0",
-    "typescript": "^5",
-    "jest": "^29.7.0"
+    "jest": "^29.7.0",
+    "react-test-renderer": "19.1.0",
+    "typescript": "^5"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/src/app/__tests__/signup.test.ts
+++ b/src/app/__tests__/signup.test.ts
@@ -1,0 +1,10 @@
+jest.mock('../../lib/supabase', () => ({ supabase: {} }))
+
+import { isPasswordStrong } from '../signup/page'
+
+describe('signup utilities', () => {
+  it('validates strong password', () => {
+    expect(isPasswordStrong('Abcdef1!')).toBe(true)
+    expect(isPasswordStrong('weak')).toBe(false)
+  })
+})

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -9,7 +9,7 @@ import { EMAIL_CONFIG } from '@/config/email';
 type Role = 'customer' | 'owner';
 
 // Add this function to check password strength
-const isPasswordStrong = (password: string) => {
+export const isPasswordStrong = (password: string) => {
     const minLength = 8;
     const hasUpperCase = /[A-Z]/.test(password);
     const hasLowerCase = /[a-z]/.test(password);

--- a/src/components/__tests__/FloatingSupportButton.test.tsx
+++ b/src/components/__tests__/FloatingSupportButton.test.tsx
@@ -1,0 +1,18 @@
+import renderer from 'react-test-renderer'
+import FloatingSupportButton from '../FloatingSupportButton'
+
+jest.mock('next/link', () => (props: any) => <a {...props} />)
+jest.mock('next/navigation', () => ({ usePathname: jest.fn() }))
+jest.mock('@/contexts/AuthContext', () => ({ useAuth: jest.fn() }))
+
+import { usePathname } from 'next/navigation'
+import { useAuth } from '@/contexts/AuthContext'
+
+describe('FloatingSupportButton', () => {
+  it('renders null when no user', () => {
+    ;(useAuth as jest.Mock).mockReturnValue({ user: null })
+    ;(usePathname as jest.Mock).mockReturnValue('/products')
+    const tree = renderer.create(<FloatingSupportButton />).toJSON()
+    expect(tree).toBeNull()
+  })
+})

--- a/src/utils/__tests__/classNames.test.ts
+++ b/src/utils/__tests__/classNames.test.ts
@@ -1,0 +1,8 @@
+import { classNames } from '../classNames'
+
+describe('classNames util', () => {
+  it('combines strings and objects', () => {
+    const result = classNames('foo', { bar: true, baz: false }, 'qux')
+    expect(result).toBe('foo bar qux')
+  })
+})

--- a/src/utils/__tests__/currency.test.ts
+++ b/src/utils/__tests__/currency.test.ts
@@ -1,7 +1,16 @@
-import { convertUSDtoETB } from '../currency'
+import { convertUSDtoETB, formatETB, formatCurrency } from '../currency'
 
 describe('currency utilities', () => {
   it('converts USD to ETB correctly', () => {
     expect(convertUSDtoETB(2)).toBe(110)
+  })
+
+  it('formats ETB amounts correctly', () => {
+    const formatted = formatETB(99)
+    expect(formatted.includes('99.00')).toBe(true)
+  })
+
+  it('formats nullable values as currency', () => {
+    expect(formatCurrency(null)).toBe('ETB\u00a00.00')
   })
 })

--- a/src/utils/__tests__/permissions.test.ts
+++ b/src/utils/__tests__/permissions.test.ts
@@ -1,0 +1,15 @@
+import { getRolePermissions } from '../permissions'
+
+describe('role permissions', () => {
+  it('returns admin permissions', () => {
+    const perms = getRolePermissions('admin', true)
+    expect(perms.canManageUsers).toBe(true)
+    expect(perms.canManageProducts).toBe(false)
+  })
+
+  it('returns owner permissions with admin flag', () => {
+    const perms = getRolePermissions('owner', true)
+    expect(perms.canViewRevenue).toBe(true)
+    expect(perms.canManageProducts).toBe(true)
+  })
+})

--- a/src/utils/__tests__/telebirr-payment.test.ts
+++ b/src/utils/__tests__/telebirr-payment.test.ts
@@ -1,0 +1,30 @@
+jest.mock('../../lib/telebirr/services', () => ({
+  applyFabricToken: jest.fn(),
+  createOrder: jest.fn()
+}))
+
+import { TelebirrPayment } from '../../lib/telebirr/payment'
+import * as services from '../../lib/telebirr/services'
+
+describe('TelebirrPayment', () => {
+  it('creates order and returns payment url', async () => {
+    jest.spyOn(services, 'applyFabricToken').mockResolvedValue({ token: 'tok' } as any)
+    jest.spyOn(services, 'createOrder').mockResolvedValue('http://pay.test')
+    const config = {
+      baseUrl: 'b',
+      webBaseUrl: 'w',
+      merchantAppId: 'm',
+      fabricAppId: 'f',
+      appSecret: 'a',
+      privateKey: 'p',
+      shortCode: 's',
+      notifyUrl: 'n',
+      redirectUrl: 'r'
+    }
+    const tp = new TelebirrPayment(config as any)
+    const url = await tp.createOrder({ title: 't', amount: '10' })
+    expect(url).toBe('http://pay.test')
+    expect(services.applyFabricToken).toHaveBeenCalled()
+    expect(services.createOrder).toHaveBeenCalledWith(expect.objectContaining({ fabricToken: 'tok' }))
+  })
+})

--- a/src/utils/__tests__/tools.test.ts
+++ b/src/utils/__tests__/tools.test.ts
@@ -1,0 +1,14 @@
+import { tools } from '../tools'
+
+describe('tools utilities', () => {
+  it('creates 32 char nonce', () => {
+    const nonce = tools.createNonceStr()
+    expect(nonce).toHaveLength(32)
+  })
+
+  it('creates timestamp string', () => {
+    const ts = tools.createTimeStamp()
+    expect(typeof ts).toBe('string')
+    expect(ts.length).toBeGreaterThan(0)
+  })
+})

--- a/src/utils/__tests__/url.test.ts
+++ b/src/utils/__tests__/url.test.ts
@@ -1,0 +1,22 @@
+import { cleanImageUrl, normalizeUrl, getAppUrl } from '../url'
+
+describe('url utilities', () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://supabase.test'
+    process.env.NEXT_PUBLIC_SITE_URL = 'https://myapp.test'
+  })
+
+  it('normalizes urls correctly', () => {
+    const url = normalizeUrl('https://example.com/', '/path')
+    expect(url).toBe('https://example.com/path')
+  })
+
+  it('returns cleaned supabase url for filename', () => {
+    const url = cleanImageUrl('image.png')
+    expect(url).toBe('https://supabase.test/storage/v1/object/public/products/image.png')
+  })
+
+  it('gets app url from env', () => {
+    expect(getAppUrl()).toBe('https://myapp.test')
+  })
+})


### PR DESCRIPTION
## Summary
- export password helper in signup page
- add tests for currency utils and general utilities
- cover Telebirr payment helper
- add component test for FloatingSupportButton
- verify password strength logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841c94463ec832f983e1dcba77a1261