### PR TITLE
Add client logging API and utility

### DIFF
--- a/src/app/api/client-log/route.ts
+++ b/src/app/api/client-log/route.ts
@@ -1,0 +1,33 @@
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+
+// Fallback to service role for unauthenticated logs
+const serviceClient = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);
+
+export async function POST(request: Request) {
+  try {
+    const cookieStore = cookies();
+    const routeClient = createRouteHandlerClient({ cookies: () => cookieStore });
+
+    const { data: sessionData } = await routeClient.auth.getSession();
+    const userId = sessionData.session?.user.id || null;
+
+    const { message, level = 'info', data } = await request.json();
+
+    const { error } = await serviceClient
+      .from('client_logs')
+      .insert({ message, level, data, user_id: userId });
+
+    if (error) throw error;
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Error saving client log:', error);
+    return NextResponse.json({ success: false }, { status: 500 });
+  }
+}

--- a/src/app/payment/mobile-tracking/page.tsx
+++ b/src/app/payment/mobile-tracking/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { createClientComponent } from '@/lib/supabase';
 import { toast } from 'react-hot-toast';
+import { clientLog } from '@/utils/clientLog';
 
 export default function MobilePaymentTracking() {
   const router = useRouter();
@@ -28,11 +29,13 @@ export default function MobilePaymentTracking() {
 
     const paymentData = JSON.parse(pendingPayment);
     console.log('[MOBILE TRACKING] Payment data from localStorage:', paymentData);
+    clientLog('[MOBILE TRACKING] Payment data from localStorage', paymentData);
 
     const checkPaymentStatus = async () => {
       try {
         const transactionRef = tx_ref || paymentData.tx_ref;
         console.log('[MOBILE TRACKING] Using transaction reference:', transactionRef);
+        clientLog('[MOBILE TRACKING] Using transaction reference', { transactionRef });
 
         if (!transactionRef) {
           throw new Error('No transaction reference found');
@@ -41,8 +44,9 @@ export default function MobilePaymentTracking() {
         // First verify with Chapa directly
         const verifyResponse = await fetch(`/api/payments/chapa/verify?tx_ref=${transactionRef}`);
         const verifyData = await verifyResponse.json();
-        
+
         console.log('[MOBILE TRACKING] Chapa verification response:', verifyData);
+        clientLog('[MOBILE TRACKING] Chapa verification response', verifyData);
 
         // Check if payment is successful
         if (verifyData.status === 'success' && verifyData.data?.status === 'success') {
@@ -70,6 +74,7 @@ export default function MobilePaymentTracking() {
 
           if (ordersError || !orders) {
             console.error('[MOBILE TRACKING] Order fetch error:', ordersError);
+            clientLog('[MOBILE TRACKING] Order fetch error', ordersError, 'error');
             return false;
           }
 
@@ -119,6 +124,7 @@ export default function MobilePaymentTracking() {
 
           if (transactionError) {
             console.error('[MOBILE TRACKING] Transaction creation error:', transactionError);
+            clientLog('[MOBILE TRACKING] Transaction creation error', transactionError, 'error');
             return false;
           }
 
@@ -140,10 +146,12 @@ export default function MobilePaymentTracking() {
 
           if (updateError) {
             console.error('[MOBILE TRACKING] Order update error:', updateError);
+            clientLog('[MOBILE TRACKING] Order update error', updateError, 'error');
             return false;
           }
 
           console.log('[MOBILE TRACKING] Payment processed successfully');
+          clientLog('[MOBILE TRACKING] Payment processed successfully');
           localStorage.removeItem('pendingPayment');
           toast.success('Payment successful! Redirecting to your orders...');
           router.push('/orders');
@@ -151,14 +159,17 @@ export default function MobilePaymentTracking() {
         } else if (verifyData.status === 'pending') {
           // Payment is still processing
           console.log('[MOBILE TRACKING] Payment is still pending');
+          clientLog('[MOBILE TRACKING] Payment is still pending');
           return false;
         } else {
           // Payment failed or other status
           console.error('[MOBILE TRACKING] Payment verification failed:', verifyData);
+          clientLog('[MOBILE TRACKING] Payment verification failed', verifyData, 'error');
           return false;
         }
       } catch (error) {
         console.error('[MOBILE TRACKING] Error:', error);
+        clientLog('[MOBILE TRACKING] Error', error, 'error');
         return false;
       }
     };

--- a/src/utils/clientLog.ts
+++ b/src/utils/clientLog.ts
@@ -1,0 +1,13 @@
+export async function clientLog(message: string, data?: any, level: 'info' | 'warn' | 'error' = 'info') {
+  try {
+    await fetch('/api/client-log', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ message, level, data })
+    });
+  } catch (err) {
+    console.error('Failed to send client log', err);
+  }
+}

--- a/supabase/migrations/20250610180414_create_client_logs_table.sql
+++ b/supabase/migrations/20250610180414_create_client_logs_table.sql
@@ -1,0 +1,22 @@
+create table public.client_logs (
+  id uuid not null default gen_random_uuid(),
+  user_id uuid null references auth.users(id) on delete set null,
+  level text not null default 'info',
+  message text not null,
+  data jsonb null,
+  created_at timestamp with time zone not null default now(),
+  constraint client_logs_pkey primary key (id)
+);
+
+alter table public.client_logs enable row level security;
+
+create policy "Users can insert their own client logs" on public.client_logs
+  for insert
+  with check (auth.uid() = user_id);
+
+create policy "Users can view their own client logs" on public.client_logs
+  for select
+  using (auth.uid() = user_id);
+
+grant usage on schema public to authenticated;
+grant all on public.client_logs to authenticated;


### PR DESCRIPTION
## Summary
- create `client_logs` table migration for Supabase
- add API route for saving client logs
- add client logging helper
- log client payment tracking events via new API

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npx tsc -p tsconfig.json --noEmit` *(hangs without output)*

------
https://chatgpt.com/codex/tasks/task_e_684870d88544832f82bb968edd2f728f